### PR TITLE
README: Correct misspelling of "Electrode"

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Electorde Hapi Compatibility Utility
+# Electrode Hapi Compatibility Utility
 
 A utility function that detects the Hapi version and return the appropriate plugin function.
 


### PR DESCRIPTION
Just happened across this repo and saw "Electrode" was misspelled in the README title.  

It's also misspelled in the repo description ("Electorde Hapi Compatibility Utility"), but I can't edit that