### PR TITLE
CEECORE-912, update electrode-hapi-compat to be aware of @hapi/hapi 18

### DIFF
--- a/lib/is-valid-object.js
+++ b/lib/is-valid-object.js
@@ -1,0 +1,10 @@
+"use strict";
+
+function isValidObject(obj) {
+  if (typeof obj === "object" && obj !== null) {
+    return Object.keys(obj).length;
+  }
+  return false;
+}
+
+module.exports = isValidObject;

--- a/lib/is-valid-object.js
+++ b/lib/is-valid-object.js
@@ -2,7 +2,7 @@
 
 function isValidObject(obj) {
   if (typeof obj === "object" && obj !== null) {
-    return Object.keys(obj).length;
+    return Object.keys(obj).length > 0;
   }
   return false;
 }

--- a/lib/try-require.js
+++ b/lib/try-require.js
@@ -1,0 +1,13 @@
+"use strict";
+/* eslint-disable global-require */
+function tryRequire(file) {
+  let fileContent;
+  try {
+    fileContent = require(file);
+  } catch (err) {
+    // ignore
+  }
+  return fileContent;
+}
+
+module.exports = tryRequire;

--- a/lib/try-require.js
+++ b/lib/try-require.js
@@ -1,13 +1,11 @@
 "use strict";
 /* eslint-disable global-require */
 function tryRequire(file) {
-  let fileContent;
   try {
-    fileContent = require(file);
+    return require(file);
   } catch (err) {
-    // ignore
+    return undefined;
   }
-  return fileContent;
 }
 
 module.exports = tryRequire;

--- a/lib/util.js
+++ b/lib/util.js
@@ -1,40 +1,58 @@
 "use strict";
 /* eslint-disable global-require */
+const isValidObject = require("./is-valid-object");
 
 const HAPI16 = 16;
 const HAPI17 = 17;
+const HAPI18 = 18;
 
 function hapiMajor() {
   let hapiPkg;
   try {
-    hapiPkg = require("hapi/package");
+    hapiPkg = require("@hapi/hapi/package");
   } catch (err) {
-    // ignore
+    hapiPkg = require("hapi/package");
   }
-  return hapiPkg ? +hapiPkg.version.split(".")[0] : HAPI16;
+
+  if (isValidObject(hapiPkg) && hapiPkg.version) {
+    return +hapiPkg.version.split(".")[0];
+  }
+
+  return HAPI16;
 }
-let _isHapi17 = hapiMajor() >= HAPI17;
+
+const hapiV = hapiMajor();
+let _isHapi17 = hapiV >= HAPI17;
+let _isHapi18 = hapiV === HAPI18;
 
 function isHapi17() {
   return _isHapi17;
+}
+
+function isHapi18() {
+  return _isHapi18;
 }
 
 function _testSetHapi17(isHapi17Flag) {
   _isHapi17 = isHapi17Flag;
 }
 
+function _testSetHapi18(isHapi18Flag) {
+  _isHapi18 = isHapi18Flag;
+}
+
 /**
  * Detects the installed Hapi version and use the appropriate plugin
  *
- * @param {*} registers: { hapi16, hapi17 } contains registers for hapi16, hapi17
+ * @param {*} registers: { hapi16, hapi17/hapi18 } contains registers for hapi16, hapi17
  * @param {*} pkg : package for a hapi plugin
  * @returns {*}: Hapi plugin appropriate for installed version
  *
  */
 function universalHapiPlugin(registers, pkg) {
-  if (isHapi17()) {
+  if (_isHapi17 || _isHapi18) {
     return {
-      register: registers.hapi17,
+      register: _isHapi18 ? registers.hapi18 : registers.hapi17,
       pkg
     };
   } else {
@@ -47,6 +65,8 @@ function universalHapiPlugin(registers, pkg) {
 
 module.exports = {
   isHapi17,
+  isHapi18,
   universalHapiPlugin,
-  _testSetHapi17
+  _testSetHapi17,
+  _testSetHapi18
 };

--- a/lib/util.js
+++ b/lib/util.js
@@ -1,17 +1,16 @@
 "use strict";
 /* eslint-disable global-require */
 const isValidObject = require("./is-valid-object");
+const tryRequire = require("./try-require");
 
 const HAPI16 = 16;
 const HAPI17 = 17;
 const HAPI18 = 18;
 
 function hapiMajor() {
-  let hapiPkg;
-  try {
-    hapiPkg = require("@hapi/hapi/package");
-  } catch (err) {
-    hapiPkg = require("hapi/package");
+  let hapiPkg = tryRequire("@hapi/hapi/package");
+  if (!hapiPkg) {
+    hapiPkg = tryRequire("hapi/package");
   }
 
   if (isValidObject(hapiPkg) && hapiPkg.version) {
@@ -23,13 +22,13 @@ function hapiMajor() {
 
 const hapiV = hapiMajor();
 let _isHapi17 = hapiV >= HAPI17;
-let _isHapi18 = hapiV === HAPI18;
+let _isHapi18 = hapiV >= HAPI18;
 
 function isHapi17() {
   return _isHapi17;
 }
 
-function isHapi18() {
+function isHapi18OrUp() {
   return _isHapi18;
 }
 
@@ -44,7 +43,7 @@ function _testSetHapi18(isHapi18Flag) {
 /**
  * Detects the installed Hapi version and use the appropriate plugin
  *
- * @param {*} registers: { hapi16, hapi17/hapi18 } contains registers for hapi16, hapi17
+ * @param {*} registers: { hapi16, hapi17 } contains registers for hapi16, hapi17/18
  * @param {*} pkg : package for a hapi plugin
  * @returns {*}: Hapi plugin appropriate for installed version
  *
@@ -52,7 +51,7 @@ function _testSetHapi18(isHapi18Flag) {
 function universalHapiPlugin(registers, pkg) {
   if (_isHapi17 || _isHapi18) {
     return {
-      register: _isHapi18 ? registers.hapi18 : registers.hapi17,
+      register: registers.hapi17OrUp || registers.hapi17,
       pkg
     };
   } else {
@@ -64,8 +63,9 @@ function universalHapiPlugin(registers, pkg) {
 }
 
 module.exports = {
+  hapiMajor,
   isHapi17,
-  isHapi18,
+  isHapi18OrUp,
   universalHapiPlugin,
   _testSetHapi17,
   _testSetHapi18

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "electrode-hapi-compat",
   "version": "1.0.0",
-  "description": "Electrode Hapi 16/17 utility",
+  "description": "Electrode Hapi 16/17/18 utility",
   "main": "index.js",
   "scripts": {
     "test": "clap check"

--- a/test/spec/util.spec.js
+++ b/test/spec/util.spec.js
@@ -50,21 +50,22 @@ describe("Util", () => {
   it("test is hapi 18", () => {
     mockRequire("@hapi/hapi/package", { version: "18.3.2" });
     index = require("../../lib/util");
-    expect(index.isHapi18()).true;
+    expect(index.isHapi18OrUp()).true;
   });
 
   it("test is not hapi 18", () => {
     index = require("../../lib/util");
-    expect(index.isHapi18()).false;
+    expect(index.isHapi18OrUp()).false;
   });
   it("test allow tests to set isHapi18 flag", () => {
     index = require("../../lib/util");
-    expect(index.isHapi18()).false;
+    expect(index.isHapi18OrUp()).false;
     index._testSetHapi18(true);
-    expect(index.isHapi18()).true;
+    expect(index.isHapi18OrUp()).true;
   });
 
-  it("test no hapi defaults hapi 16", () => {
+  it("test no hapi, defaults hapi 16", () => {
+    //mockRequire("@hapi/hapi/package", null);
     mockRequire("hapi/package", null);
     index = require("../../lib/util");
     expect(index.isHapi17()).false;
@@ -73,8 +74,8 @@ describe("Util", () => {
   it("test universalHapiPlugin on Hapi 16", () => {
     index = require("../../lib/util");
     const registers = {
-      hapi16: () => false,
-      hapi17: () => true
+      hapi16: () => true,
+      hapi17: () => false
     };
     const pkg = { name: "Green" };
     const plugin = index.universalHapiPlugin(registers, pkg);
@@ -86,8 +87,8 @@ describe("Util", () => {
     mockRequire("hapi/package", { version: "17.0.0" });
     index = require("../../lib/util");
     const registers = {
-      hapi17: () => true,
-      hapi18: () => false
+      hapi16: () => false,
+      hapi17: () => true
     };
     const pkg = { name: "Yellow" };
     const plugin = index.universalHapiPlugin(registers, pkg);
@@ -95,16 +96,29 @@ describe("Util", () => {
     expect(plugin.register).equal(registers.hapi17);
   });
 
-  it("test universalHapiPlugin on Hapi 18", () => {
+  it("test universalHapiPlugin on Hapi 18, using registers.hapi17", () => {
     mockRequire("hapi/package", { version: "18.3.2" });
     index = require("../../lib/util");
     const registers = {
-      hapi17: () => false,
-      hapi18: () => true
+      hapi16: () => false,
+      hapi17: () => true
     };
     const pkg = { name: "Yellow" };
     const plugin = index.universalHapiPlugin(registers, pkg);
     expect(plugin.pkg).equal(pkg);
-    expect(plugin.register).equal(registers.hapi18);
+    expect(plugin.register).equal(registers.hapi17);
+  });
+
+  it("test universalHapiPlugin on Hapi 18, using registers.hapi17OrUp", () => {
+    mockRequire("hapi/package", { version: "18.3.2" });
+    index = require("../../lib/util");
+    const registers = {
+      hapi16: () => false,
+      hapi17OrUp: () => true
+    };
+    const pkg = { name: "Yellow" };
+    const plugin = index.universalHapiPlugin(registers, pkg);
+    expect(plugin.pkg).equal(pkg);
+    expect(plugin.register).equal(registers.hapi17OrUp);
   });
 });

--- a/test/spec/util.spec.js
+++ b/test/spec/util.spec.js
@@ -40,11 +40,28 @@ describe("Util", () => {
     index = require("../../lib/util");
     expect(index.isHapi17()).false;
   });
-  it("test allow tests to set flag", () => {
+  it("test allow tests to set isHapi17 flag", () => {
     index = require("../../lib/util");
     expect(index.isHapi17()).false;
     index._testSetHapi17(true);
     expect(index.isHapi17()).true;
+  });
+
+  it("test is hapi 18", () => {
+    mockRequire("@hapi/hapi/package", { version: "18.3.2" });
+    index = require("../../lib/util");
+    expect(index.isHapi18()).true;
+  });
+
+  it("test is not hapi 18", () => {
+    index = require("../../lib/util");
+    expect(index.isHapi18()).false;
+  });
+  it("test allow tests to set isHapi18 flag", () => {
+    index = require("../../lib/util");
+    expect(index.isHapi18()).false;
+    index._testSetHapi18(true);
+    expect(index.isHapi18()).true;
   });
 
   it("test no hapi defaults hapi 16", () => {
@@ -69,12 +86,25 @@ describe("Util", () => {
     mockRequire("hapi/package", { version: "17.0.0" });
     index = require("../../lib/util");
     const registers = {
-      hapi16: () => false,
-      hapi17: () => true
+      hapi17: () => true,
+      hapi18: () => false
     };
     const pkg = { name: "Yellow" };
     const plugin = index.universalHapiPlugin(registers, pkg);
     expect(plugin.pkg).equal(pkg);
     expect(plugin.register).equal(registers.hapi17);
+  });
+
+  it("test universalHapiPlugin on Hapi 18", () => {
+    mockRequire("hapi/package", { version: "18.3.2" });
+    index = require("../../lib/util");
+    const registers = {
+      hapi17: () => false,
+      hapi18: () => true
+    };
+    const pkg = { name: "Yellow" };
+    const plugin = index.universalHapiPlugin(registers, pkg);
+    expect(plugin.pkg).equal(pkg);
+    expect(plugin.register).equal(registers.hapi18);
   });
 });


### PR DESCRIPTION
- made changes to account for @hapi/hapi package

- Following new apis exposed for hapi@18
   - isHapi18() tells(true/false) if the hapi version used is v18
   - _testSetHapi18() used to modify the above flag during writing tests for hapi@18

- hapi@18 follows the same steps to register a hapi plugin
   - universalHapiPlugin() recognizes v18 similar to v17 and registers the plugin

> The unit tests mostly defaults to v16, it's the version specified in the package.json
    -- whenever this version is changed, we might need to make appropriate unit test changes.
    -- this PR only includes new tests for v18.