### PR TITLE
work with version directly instead of flags

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -60,3 +60,4 @@ typings/
 .vscode/
 .DS_Store
 
+*-lock.*

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ Hapi 17 changed the signature of Plugins. This utility provides a simple wrapper
 
 ## Export plugin for Hapi 16 or 17+
 
-If you have module that can export plugins for hapi 16 or 17+, you can let this module automatically determine which of your plugins to use depending on the version of Hapi detected using `universalHapiPlugin`.
+If you have module that can export plugins for hapi 16 or 17+, you can use the API `universalHapiPlugin` to let this module automatically determine which of your plugins to use depending on the version of Hapi detected.
 
 ```js
 const {universalHapiPlugin} = require("electrode-hapi-compat");
@@ -23,8 +23,6 @@ const pkg = {
 
 module.exports = universalHapiPlugin(registers, pkg);
 ```
-
-Specify the Hapi 16 and Hapi 17 plugins. This utility reads the Hapi version and returns the appropriate register function.
 
 ## Checking for Hapi 17 or Up
 

--- a/README.md
+++ b/README.md
@@ -2,17 +2,20 @@
 
 A utility function that detects the Hapi version and return the appropriate plugin function.
 
-Hapi 17 changed the signature of Plugins. This utility provides a simple wrapper for your plugin to support both Hapi 16 and Hapi 17.
+Hapi 17 changed the signature of Plugins. This utility provides a simple wrapper for your plugin to support both Hapi 16 and Hapi 17+.
 
-# Usage
+## Export plugin for Hapi 16 or 17+
 
-```
+If you have module that can export plugins for hapi 16 or 17+, you can let this module automatically determine which of your plugins to use depending on the version of Hapi detected using `universalHapiPlugin`.
+
+```js
 const {universalHapiPlugin} = require("electrode-hapi-compat");
 
 const registers = {
   hapi16: (server, options, next) => {...},
-  hapi17: (server, options) => {...}
+  hapi17OrUp: (server, options) => {...}
 };
+
 const pkg = {
   name: "MyPackage",
   version: "1.0.0"
@@ -23,58 +26,53 @@ module.exports = universalHapiPlugin(registers, pkg);
 
 Specify the Hapi 16 and Hapi 17 plugins. This utility reads the Hapi version and returns the appropriate register function.
 
-## Checking for Hapi 17
+## Checking for Hapi 17 or Up
 
 ```js
-const {isHapi17} = require("electrode-hapi-compat");
+const { isHapi17OrUp } = require("electrode-hapi-compat");
 
-if(isHapi17()) {
-// hapi 17
+if (isHapi17OrUp()) {
+  // hapi 17 or @hapi/hapi >= 18
 } else {
-// hapi 16
+  // hapi 16
 }
 ```
 
-## Checking for Hapi 18
+## Checking for Hapi 18 or Up
 
 ```js
 // this is to identify if @hapi/hapi v18 and above
-const {isHapi18OrUp} = require("electrode-hapi-compat");
+const { isHapi18OrUp } = require("electrode-hapi-compat");
 
-if(isHapi18OrUp()) {
-// @hapi/hapi >= 18
+if (isHapi18OrUp()) {
+  // @hapi/hapi >= 18
 } else {
-// hapi 16/17
+  // hapi 16/17
 }
 ```
 
-## Testing
-To test a module that uses this library, use the `_testSetHapi17()` function.
+## Manually Setting Version for Testing
+
+If you need to manually force a certain version of Hapi for testing etc,
+you can manually set the Hapi major version this module should use with the `hapiVersion` property:
 
 ```js
-const {_testSetHapi17} = require("electrode-hapi-compat");
+// Set to use Hapi major version 18
 
-it("Test Hapi 17", () => {
-  _testSetHapi17(true);
-  delete require.cache["my-module-that-uses-hapi-compat"];
-  const module = require("my-module-that-uses-hapi-compat");
-  
-  // test hapi 17 module
-  module.isHapi17();    // true
-});
+require("electrode-hapi-compat").hapiVersion = 18;
+
+// Get Hapi major version
+
+const hapiVersion = require("electrode-hapi-compat").hapiVersion;
 ```
-```_testSetHapi18()``` would do the same as above but for @hapi/hapi v18 and above
 
-Note the function needs to be called before you import the library.  Also delete your require cache for that library.
-
-
-# Install
+## Install
 
 ```bash
 $ npm install --save electrode-hapi-compat
 ```
 
-# Contribute
+## Contribute
 
 1. Clone this repo
 2. Make updates

--- a/index.js
+++ b/index.js
@@ -1,1 +1,0 @@
-module.exports = require("./lib/util");

--- a/lib/util.js
+++ b/lib/util.js
@@ -1,43 +1,51 @@
 "use strict";
-/* eslint-disable global-require */
+
+/* eslint-disable no-magic-numbers */
+
 const isValidObject = require("./is-valid-object");
 const tryRequire = require("./try-require");
 
-const HAPI16 = 16;
-const HAPI17 = 17;
-const HAPI18 = 18;
+let HAPI_MAJOR_VERSION;
 
 function hapiMajor() {
-  let hapiPkg = tryRequire("@hapi/hapi/package");
-  if (!hapiPkg) {
-    hapiPkg = tryRequire("hapi/package");
+  if (HAPI_MAJOR_VERSION === undefined) {
+    HAPI_MAJOR_VERSION = 16;
+
+    let hapiPkg = tryRequire("@hapi/hapi/package");
+    if (!hapiPkg) {
+      hapiPkg = tryRequire("hapi/package");
+    }
+
+    if (isValidObject(hapiPkg) && hapiPkg.version) {
+      HAPI_MAJOR_VERSION = +hapiPkg.version.split(".")[0];
+    }
   }
 
-  if (isValidObject(hapiPkg) && hapiPkg.version) {
-    return +hapiPkg.version.split(".")[0];
-  }
-
-  return HAPI16;
+  return HAPI_MAJOR_VERSION;
 }
 
-const hapiV = hapiMajor();
-let _isHapi17 = hapiV >= HAPI17;
-let _isHapi18 = hapiV >= HAPI18;
-
 function isHapi17() {
-  return _isHapi17;
+  return hapiMajor() >= 17;
 }
 
 function isHapi18OrUp() {
-  return _isHapi18;
+  return hapiMajor() >= 18;
 }
 
 function _testSetHapi17(isHapi17Flag) {
-  _isHapi17 = isHapi17Flag;
+  if (isHapi17Flag) {
+    HAPI_MAJOR_VERSION = 17;
+  } else if (HAPI_MAJOR_VERSION === 17) {
+    HAPI_MAJOR_VERSION = 16;
+  }
 }
 
 function _testSetHapi18(isHapi18Flag) {
-  _isHapi18 = isHapi18Flag;
+  if (isHapi18Flag) {
+    HAPI_MAJOR_VERSION = 18;
+  } else if (HAPI_MAJOR_VERSION === 18) {
+    HAPI_MAJOR_VERSION = 17;
+  }
 }
 
 /**
@@ -49,7 +57,7 @@ function _testSetHapi18(isHapi18Flag) {
  *
  */
 function universalHapiPlugin(registers, pkg) {
-  if (_isHapi17 || _isHapi18) {
+  if (hapiMajor() >= 17) {
     return {
       register: registers.hapi17OrUp || registers.hapi17,
       pkg
@@ -64,9 +72,15 @@ function universalHapiPlugin(registers, pkg) {
 
 module.exports = {
   hapiMajor,
-  isHapi17,
+  isHapi17OrUp: isHapi17,
   isHapi18OrUp,
   universalHapiPlugin,
   _testSetHapi17,
-  _testSetHapi18
+  _testSetHapi18,
+  isHapi17
 };
+
+Object.defineProperty(module.exports, "hapiVersion", {
+  get: () => hapiMajor(),
+  set: v => (HAPI_MAJOR_VERSION = v)
+});

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "electrode-hapi-compat",
   "version": "1.1.0",
   "description": "Electrode Hapi 16/17/18 utility",
-  "main": "index.js",
+  "main": "lib/util.js",
   "scripts": {
     "test": "clap check"
   },

--- a/test/spec/util.spec.js
+++ b/test/spec/util.spec.js
@@ -2,6 +2,7 @@
 
 const hapi = require("hapi");
 const mockRequire = require("mock-require");
+const compat = require("../..");
 
 describe("Util", () => {
   let index;
@@ -40,6 +41,7 @@ describe("Util", () => {
     index = require("../../lib/util");
     expect(index.isHapi17()).false;
   });
+
   it("test allow tests to set isHapi17 flag", () => {
     index = require("../../lib/util");
     expect(index.isHapi17()).false;
@@ -57,6 +59,7 @@ describe("Util", () => {
     index = require("../../lib/util");
     expect(index.isHapi18OrUp()).false;
   });
+
   it("test allow tests to set isHapi18 flag", () => {
     index = require("../../lib/util");
     expect(index.isHapi18OrUp()).false;
@@ -120,5 +123,41 @@ describe("Util", () => {
     const plugin = index.universalHapiPlugin(registers, pkg);
     expect(plugin.pkg).equal(pkg);
     expect(plugin.register).equal(registers.hapi17OrUp);
+  });
+
+  it("_testSetHapi17 should set version to 17 for true", () => {
+    compat.hapiVersion = 18;
+    compat._testSetHapi17(true);
+    expect(compat.hapiVersion).equals(17);
+  });
+
+  it("_testSetHapi17 should set version to 16 for 17 and false", () => {
+    compat.hapiVersion = 17;
+    compat._testSetHapi17(false);
+    expect(compat.hapiVersion).equals(16);
+  });
+
+  it("_testSetHapi17 should do nothing for version !== 17 and false", () => {
+    compat.hapiVersion = 18;
+    compat._testSetHapi17(false);
+    expect(compat.hapiVersion).equals(18);
+  });
+
+  it("_testSetHapi18 should set version to 18 for true", () => {
+    compat.hapiVersion = 16;
+    compat._testSetHapi18(true);
+    expect(compat.hapiVersion).equals(18);
+  });
+
+  it("_testSetHapi18 should set version to 17 for 18 and false", () => {
+    compat.hapiVersion = 18;
+    compat._testSetHapi18(false);
+    expect(compat.hapiVersion).equals(17);
+  });
+
+  it("_testSetHapi18 should do nothing for version !== 18 and false", () => {
+    compat.hapiVersion = 16;
+    compat._testSetHapi18(false);
+    expect(compat.hapiVersion).equals(16);
   });
 });

--- a/test/spec/util.spec.js
+++ b/test/spec/util.spec.js
@@ -22,7 +22,7 @@ describe("Util", () => {
 
   afterEach(() => {
     hapiServer.stop();
-    delete require.cache[require.resolve("../../lib/util")];
+    delete require.cache[require.resolve("../..")];
     mockRequire.stopAll();
   });
 
@@ -33,17 +33,17 @@ describe("Util", () => {
 
   it("test is hapi 17", () => {
     mockRequire("hapi/package", { version: "17.2.2" });
-    index = require("../../lib/util");
+    index = require("../..");
     expect(index.isHapi17()).true;
   });
 
   it("test is not hapi 17", () => {
-    index = require("../../lib/util");
+    index = require("../..");
     expect(index.isHapi17()).false;
   });
 
   it("test allow tests to set isHapi17 flag", () => {
-    index = require("../../lib/util");
+    index = require("../..");
     expect(index.isHapi17()).false;
     index._testSetHapi17(true);
     expect(index.isHapi17()).true;
@@ -51,17 +51,17 @@ describe("Util", () => {
 
   it("test is hapi 18", () => {
     mockRequire("@hapi/hapi/package", { version: "18.3.2" });
-    index = require("../../lib/util");
+    index = require("../..");
     expect(index.isHapi18OrUp()).true;
   });
 
   it("test is not hapi 18", () => {
-    index = require("../../lib/util");
+    index = require("../..");
     expect(index.isHapi18OrUp()).false;
   });
 
   it("test allow tests to set isHapi18 flag", () => {
-    index = require("../../lib/util");
+    index = require("../..");
     expect(index.isHapi18OrUp()).false;
     index._testSetHapi18(true);
     expect(index.isHapi18OrUp()).true;
@@ -70,12 +70,12 @@ describe("Util", () => {
   it("test no hapi, defaults hapi 16", () => {
     //mockRequire("@hapi/hapi/package", null);
     mockRequire("hapi/package", null);
-    index = require("../../lib/util");
+    index = require("../..");
     expect(index.isHapi17()).false;
   });
 
   it("test universalHapiPlugin on Hapi 16", () => {
-    index = require("../../lib/util");
+    index = require("../..");
     const registers = {
       hapi16: () => true,
       hapi17: () => false
@@ -88,7 +88,7 @@ describe("Util", () => {
 
   it("test universalHapiPlugin on Hapi 17", () => {
     mockRequire("hapi/package", { version: "17.0.0" });
-    index = require("../../lib/util");
+    index = require("../..");
     const registers = {
       hapi16: () => false,
       hapi17: () => true
@@ -101,7 +101,7 @@ describe("Util", () => {
 
   it("test universalHapiPlugin on Hapi 18, using registers.hapi17", () => {
     mockRequire("hapi/package", { version: "18.3.2" });
-    index = require("../../lib/util");
+    index = require("../..");
     const registers = {
       hapi16: () => false,
       hapi17: () => true
@@ -114,7 +114,7 @@ describe("Util", () => {
 
   it("test universalHapiPlugin on Hapi 18, using registers.hapi17OrUp", () => {
     mockRequire("hapi/package", { version: "18.3.2" });
-    index = require("../../lib/util");
+    index = require("../..");
     const registers = {
       hapi16: () => false,
       hapi17OrUp: () => true


### PR DESCRIPTION
Using a flag for each version becomes hard to manage, so switch to work with version directly.

For example, tests can just override with `compat.hapiVersion = 16`, or check with `compat.hapiVersion >= 17`
